### PR TITLE
Nix tooling improvements

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
 use flake
+[ -d .venv ] && source .venv/bin/activate

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
   in {
     devShells = eachSystem ({pkgs, ...}: {
       default = pkgs.mkShell {
-        packages = with pkgs; [python3 uv ruff black];
+        packages = with pkgs; [python3 uv ruff black nodejs];
         LD_LIBRARY_PATH = lib.concatMapStringsSep ":" (l: "${lib.getLib l}/lib") [pkgs.stdenv.cc.cc pkgs.zlib];
       };
     });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,6 @@ pythonpath = ["mousemetrics"]
 
 [tool.pyright]
 include = ["mousemetrics"]
-exclude = ["**/migrations", ".venv", "mousemetrics/mouseapp/admin.py"]
+exclude = ["**/migrations", ".venv", ".direnv", "mousemetrics/mouseapp/admin.py"]
 typeCheckingMode = "basic"
 reportMissingTypeStubs = false


### PR DESCRIPTION
Ignore .direnv for pyright because otherwise all of [nixpkgs](https://github.com/NixOS/nixpkgs/) gets typechecked; there's a symlink